### PR TITLE
Added port to listen on flag

### DIFF
--- a/gitmirror.go
+++ b/gitmirror.go
@@ -17,6 +17,7 @@ import (
 
 var thePath = flag.String("dir", "/tmp", "working directory")
 var git = flag.String("git", "/usr/bin/git", "path to git")
+var port = flag.Int("port", 8124, "port to listen on")
 
 type commandRequest struct {
 	w       http.ResponseWriter
@@ -273,5 +274,7 @@ func main() {
 		func(w http.ResponseWriter, req *http.Request) {
 			http.Error(w, "No favicon", http.StatusGone)
 		})
-	log.Fatal(http.ListenAndServe(":8124", nil))
+
+	addr := fmt.Sprintf(":%d", *port)
+	log.Fatal(http.ListenAndServe(addr, nil))
 }


### PR DESCRIPTION
Added port to listen on flag. Default is 8124. You can now specify the port to listen on when starting gitmirror.

/path/to/gitmirror -git=/path/to/git -dir=/tmp/gitmirrors -port=8080
